### PR TITLE
Fix left shift of 1 by 31 places in print_bitmask

### DIFF
--- a/drm_info.c
+++ b/drm_info.c
@@ -637,7 +637,7 @@ static void print_bitmask(uint32_t mask)
 {
 	bool first = true;
 	printf("{");
-	for (uint32_t i = 0; i < 32; ++i) {
+	for (uint32_t i = 0; i < 31; ++i) {
 		if (!(mask & (1 << i)))
 			continue;
 


### PR DESCRIPTION
UBSan prints this error message:

    ../drm_info.c:641:19: runtime error: left shift of 1 by 31 places cannot be represented in type 'int'