### PR TITLE
Add support for more mode flags

### DIFF
--- a/drm_info.c
+++ b/drm_info.c
@@ -408,6 +408,23 @@ static void print_mode(const drmModeModeInfo *mode)
 		printf("dblclk ");
 	if (mode->flags & DRM_MODE_FLAG_CLKDIV2)
 		printf("clkdiv2 ");
+
+	switch (mode->flags & DRM_MODE_FLAG_PIC_AR_MASK) {
+	case DRM_MODE_FLAG_PIC_AR_NONE:
+		break;
+	case DRM_MODE_FLAG_PIC_AR_4_3:
+		printf("4:3 ");
+		break;
+	case DRM_MODE_FLAG_PIC_AR_16_9:
+		printf("16:9 ");
+		break;
+	case DRM_MODE_FLAG_PIC_AR_64_27:
+		printf("64:27 ");
+		break;
+	case DRM_MODE_FLAG_PIC_AR_256_135:
+		printf("256:135 ");
+		break;
+	}
 }
 
 static void print_mode_id(int fd, uint32_t id, const char *prefix)

--- a/drm_info.c
+++ b/drm_info.c
@@ -377,16 +377,8 @@ static void print_mode(const drmModeModeInfo *mode)
 	printf("%"PRIu16"x%"PRIu16"@%.02f ", mode->hdisplay, mode->vdisplay,
 		refresh_rate(mode) / 1000.0);
 
-	if (mode->type & DRM_MODE_TYPE_BUILTIN)
-		printf("builtin ");
-	if (mode->type & DRM_MODE_TYPE_CLOCK_C)
-		printf("clock_c ");
-	if (mode->type & DRM_MODE_TYPE_CRTC_C)
-		printf("crtc_c ");
 	if (mode->type & DRM_MODE_TYPE_PREFERRED)
 		printf("preferred ");
-	if (mode->type & DRM_MODE_TYPE_DEFAULT)
-		printf("default ");
 	if (mode->type & DRM_MODE_TYPE_USERDEF)
 		printf("userdef ");
 	if (mode->type & DRM_MODE_TYPE_DRIVER)
@@ -412,10 +404,6 @@ static void print_mode(const drmModeModeInfo *mode)
 		printf("nvsync ");
 	if (mode->flags & DRM_MODE_FLAG_HSKEW)
 		printf("hskew ");
-	if (mode->flags & DRM_MODE_FLAG_BCAST)
-		printf("bcast ");
-	if (mode->flags & DRM_MODE_FLAG_PIXMUX)
-		printf("pixmux ");
 	if (mode->flags & DRM_MODE_FLAG_DBLCLK)
 		printf("dblclk ");
 	if (mode->flags & DRM_MODE_FLAG_CLKDIV2)

--- a/drm_info.c
+++ b/drm_info.c
@@ -425,6 +425,35 @@ static void print_mode(const drmModeModeInfo *mode)
 		printf("256:135 ");
 		break;
 	}
+
+	switch (mode->flags & DRM_MODE_FLAG_3D_MASK) {
+	case DRM_MODE_FLAG_3D_NONE:
+		break;
+	case DRM_MODE_FLAG_3D_FRAME_PACKING:
+		printf("3d-frame-packing ");
+		break;
+	case DRM_MODE_FLAG_3D_FIELD_ALTERNATIVE:
+		printf("3d-field-alternative ");
+		break;
+	case DRM_MODE_FLAG_3D_LINE_ALTERNATIVE:
+		printf("3d-line-alternative ");
+		break;
+	case DRM_MODE_FLAG_3D_SIDE_BY_SIDE_FULL:
+		printf("3d-side-by-side-full ");
+		break;
+	case DRM_MODE_FLAG_3D_L_DEPTH:
+		printf("3d-l-depth ");
+		break;
+	case DRM_MODE_FLAG_3D_L_DEPTH_GFX_GFX_DEPTH:
+		printf("3d-l-depth-gfx-gfx-depth ");
+		break;
+	case DRM_MODE_FLAG_3D_TOP_AND_BOTTOM:
+		printf("3d-top-and-bottom ");
+		break;
+	case DRM_MODE_FLAG_3D_SIDE_BY_SIDE_HALF:
+		printf("3d-side-by-side-half ");
+		break;
+	}
 }
 
 static void print_mode_id(int fd, uint32_t id, const char *prefix)


### PR DESCRIPTION
These are flags from `DRM_CLIENT_CAP_STEREO_3D` and `DRM_CLIENT_CAP_ASPECT_RATIO`.

Some regular flags were removed, because they're marked as deprecated: https://elixir.bootlin.com/linux/latest/source/include/uapi/drm/drm_mode.h#L41

Fixes #13 