### PR TITLE
Explicit arguments

### DIFF
--- a/drm_info.h
+++ b/drm_info.h
@@ -3,7 +3,7 @@
 
 struct json_object;
 
-struct json_object *drm_info(void);
+struct json_object *drm_info(char *paths[]);
 void print_drm(struct json_object *obj);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -19,12 +19,12 @@ int main(int argc, char *argv[])
 			json = true;
 			break;
 		default:
-			fprintf(stderr, "usage: drm_info [-j]\n");
+			fprintf(stderr, "usage: drm_info [-j] [--] [path]...\n");
 			exit(opt == '?' ? EXIT_SUCCESS : EXIT_FAILURE);
 		}
 	}
 
-	struct json_object *obj = drm_info();
+	struct json_object *obj = drm_info(&argv[optind]);
 	if (json) {
 		json_object_to_fd(STDOUT_FILENO, obj,
 			JSON_C_TO_STRING_PRETTY | JSON_C_TO_STRING_SPACED);


### PR DESCRIPTION
Allows explicitly selecting the devices you look at with command line arguments, in case you only want to look at one, instead of them all.
Also adds some extra error-handling in some cases where we're given an invalid file.