### PR TITLE
Fix build on Debian stable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+subprojects/packagecache
+subprojects/json-c-0.13.1

--- a/compat.h
+++ b/compat.h
@@ -1,0 +1,122 @@
+#ifndef COMPAT_H
+#define COMPAT_H
+
+#include <drm_fourcc.h>
+#include "config.h"
+
+/*
+ * Defines for compatibility with old libdrm.
+ * The oldest version we target is whatever version Debian stable has.
+ */
+
+#define VERSION(maj, min, pat) (((maj) << 16) | ((min) << 8) | (pat))
+#define LIBDRM_VERSION VERSION(LIBDRM_MAJ, LIBDRM_MIN, LIBDRM_PAT)
+
+#if LIBDRM_VERSION < VERSION(2, 4, 75)
+#define DRM_BUS_PCI 0
+#define DRM_BUS_USB 1
+#define DRM_BUS_PLATFORM 2
+#define DRM_BUS_HOST1X 3
+#endif /* LIBDRM_VERSION < VERSION(2, 4, 75) */
+
+#if LIBDRM_VERSION < VERSION(2, 4, 78)
+#define DRM_CAP_CRTC_IN_VBLANK_EVENT 0x12
+#endif /* LIBDRM_VERSION < VERSION(2, 4, 78) */
+
+#if LIBDRM_VERSION < VERSION(2, 4, 82)
+#define DRM_CAP_SYNCOBJ 0x13
+#define DRM_FORMAT_R16 fourcc_code('R', '1', '6', ' ')
+#define DRM_FORMAT_RG1616 fourcc_code('R', 'G', '3', '2')
+#define DRM_FORMAT_GR1616 fourcc_code('G', 'R', '3', '2')
+#define DRM_FORMAT_MOD_VENDOR_VIVANTE 0x06
+#define DRM_FORMAT_MOD_VENDOR_BROADCOM 0x07
+#define DRM_FORMAT_MOD_VENDOR_NONE    0
+#define DRM_FORMAT_MOD_LINEAR	fourcc_mod_code(NONE, 0)
+#define DRM_FORMAT_MOD_VIVANTE_TILED		fourcc_mod_code(VIVANTE, 1)
+#define DRM_FORMAT_MOD_VIVANTE_SUPER_TILED	fourcc_mod_code(VIVANTE, 2)
+#define DRM_FORMAT_MOD_VIVANTE_SPLIT_TILED	fourcc_mod_code(VIVANTE, 3)
+#define DRM_FORMAT_MOD_VIVANTE_SPLIT_SUPER_TILED fourcc_mod_code(VIVANTE, 4)
+#define DRM_FORMAT_MOD_BROADCOM_VC4_T_TILED fourcc_mod_code(BROADCOM, 1)
+#endif /* LIBDRM_VERSION < VERSION(2, 4, 82) */
+
+#if LIBDRM_VERSION < VERSION(2, 4, 83)
+#define DRM_FORMAT_RESERVED	      ((1ULL << 56) - 1)
+#define DRM_FORMAT_MOD_INVALID	fourcc_mod_code(NONE, DRM_FORMAT_RESERVED)
+#define I915_FORMAT_MOD_Y_TILED_CCS	fourcc_mod_code(INTEL, 4)
+#define I915_FORMAT_MOD_Yf_TILED_CCS	fourcc_mod_code(INTEL, 5)
+#endif /* LIBDRM_VERSION < VERSION(2, 4, 83) */
+
+#if LIBDRM_VERSION < VERSION(2, 4, 86)
+#define DRM_MODE_PICTURE_ASPECT_NONE		0
+#define DRM_MODE_PICTURE_ASPECT_4_3		1
+#define DRM_MODE_PICTURE_ASPECT_16_9		2
+#define DRM_MODE_PICTURE_ASPECT_64_27		3
+#define DRM_MODE_PICTURE_ASPECT_256_135		4
+#define DRM_MODE_FLAG_PIC_AR_MASK		(0x0F<<19)
+#define  DRM_MODE_FLAG_PIC_AR_NONE (DRM_MODE_PICTURE_ASPECT_NONE<<19)
+#define  DRM_MODE_FLAG_PIC_AR_4_3 (DRM_MODE_PICTURE_ASPECT_4_3<<19)
+#define  DRM_MODE_FLAG_PIC_AR_16_9 (DRM_MODE_PICTURE_ASPECT_16_9<<19)
+#define  DRM_MODE_FLAG_PIC_AR_64_27 (DRM_MODE_PICTURE_ASPECT_64_27<<19)
+#define  DRM_MODE_FLAG_PIC_AR_256_135 (DRM_MODE_PICTURE_ASPECT_256_135<<19)
+#endif /* LIBDRM_VERSION < VERSION(2, 4, 86) */
+
+#if LIBDRM_VERSION < VERSION(2, 4, 91)
+#define DRM_FORMAT_MOD_VENDOR_NVIDIA  0x03
+#define DRM_FORMAT_MOD_NVIDIA_TEGRA_TILED fourcc_mod_code(NVIDIA, 1)
+#define DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK(v) \
+	fourcc_mod_code(NVIDIA, 0x10 | ((v) & 0xf))
+#define DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_ONE_GOB \
+	fourcc_mod_code(NVIDIA, 0x10)
+#define DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_TWO_GOB \
+	fourcc_mod_code(NVIDIA, 0x11)
+#define DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_FOUR_GOB \
+	fourcc_mod_code(NVIDIA, 0x12)
+#define DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_EIGHT_GOB \
+	fourcc_mod_code(NVIDIA, 0x13)
+#define DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_SIXTEEN_GOB \
+	fourcc_mod_code(NVIDIA, 0x14)
+#define DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_THIRTYTWO_GOB \
+	fourcc_mod_code(NVIDIA, 0x15)
+#endif /* LIBDRM_VERSION < VERSION(2, 4, 91) */
+
+#if LIBDRM_VERSION < VERSION(2, 4, 95)
+#define DRM_CLIENT_CAP_ASPECT_RATIO 4
+#define DRM_CLIENT_CAP_WRITEBACK_CONNECTORS 5
+#define DRM_FORMAT_INVALID 0
+#define DRM_MODE_CONNECTOR_WRITEBACK 18
+#define DRM_FORMAT_MOD_VENDOR_ARM     0x08
+#define __fourcc_mod_broadcom_param_shift 8
+#define __fourcc_mod_broadcom_param_bits 48
+#define fourcc_mod_broadcom_code(val, params) \
+	fourcc_mod_code(BROADCOM, ((((__u64)params) << __fourcc_mod_broadcom_param_shift) | val))
+#define fourcc_mod_broadcom_param(m) \
+	((int)(((m) >> __fourcc_mod_broadcom_param_shift) &	\
+	       ((1ULL << __fourcc_mod_broadcom_param_bits) - 1)))
+#define fourcc_mod_broadcom_mod(m) \
+	((m) & ~(((1ULL << __fourcc_mod_broadcom_param_bits) - 1) <<	\
+		 __fourcc_mod_broadcom_param_shift))
+#define DRM_FORMAT_MOD_BROADCOM_SAND32_COL_HEIGHT(v) \
+	fourcc_mod_broadcom_code(2, v)
+#define DRM_FORMAT_MOD_BROADCOM_SAND64_COL_HEIGHT(v) \
+	fourcc_mod_broadcom_code(3, v)
+#define DRM_FORMAT_MOD_BROADCOM_SAND128_COL_HEIGHT(v) \
+	fourcc_mod_broadcom_code(4, v)
+#define DRM_FORMAT_MOD_BROADCOM_SAND256_COL_HEIGHT(v) \
+	fourcc_mod_broadcom_code(5, v)
+#define DRM_FORMAT_MOD_BROADCOM_SAND32 \
+	DRM_FORMAT_MOD_BROADCOM_SAND32_COL_HEIGHT(0)
+#define DRM_FORMAT_MOD_BROADCOM_SAND64 \
+	DRM_FORMAT_MOD_BROADCOM_SAND64_COL_HEIGHT(0)
+#define DRM_FORMAT_MOD_BROADCOM_SAND128 \
+	DRM_FORMAT_MOD_BROADCOM_SAND128_COL_HEIGHT(0)
+#define DRM_FORMAT_MOD_BROADCOM_SAND256 \
+	DRM_FORMAT_MOD_BROADCOM_SAND256_COL_HEIGHT(0)
+#define DRM_FORMAT_MOD_BROADCOM_UIF fourcc_mod_code(BROADCOM, 6)
+#endif /* LIBDRM_VERSION < VERSION(2, 4, 95) */
+
+#if LIBDRM_VERSION < VERSION(2, 4, 98)
+#define DRM_FORMAT_MOD_VENDOR_ALLWINNER 0x09
+#define DRM_FORMAT_MOD_ALLWINNER_TILED fourcc_mod_code(ALLWINNER, 1)
+#endif /* LIBDRM_VERSION < VERSION(2, 4, 98) */
+
+#endif

--- a/json.c
+++ b/json.c
@@ -12,32 +12,9 @@
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 
+#include "compat.h"
 #include "config.h"
 #include "drm_info.h"
-
-// Defines for comaptibility with old libdrm
-
-// drm.h
-
-#ifndef DRM_CAP_CRTC_IN_VBLANK_EVENT
-#define DRM_CAP_CRTC_IN_VBLANK_EVENT 0x12
-#endif
-
-#ifndef DRM_CAP_SYNCOBJ
-#define DRM_CAP_SYNCOBJ 0x13
-#endif
-
-#ifndef DRM_CLIENT_CAP_ASPECT_RATIO
-#define DRM_CLIENT_CAP_ASPECT_RATIO 4
-#endif
-
-#ifndef DRM_CLIENT_CAP_WRITEBACK_CONNECTORS
-#define DRM_CLIENT_CAP_WRITEBACK_CONNECTORS 5
-#endif
-
-#ifndef DRM_MODE_CONNECTOR_WRITEBACK
-#define DRM_MODE_CONNECTOR_WRITEBACK 18
-#endif
 
 static const struct {
 	const char *name;
@@ -172,7 +149,7 @@ static struct json_object *device_info(int fd)
 	return obj;
 }
 
-#if HAVE_LIBDRM_2_4_83
+#if LIBDRM_VERSION >= VERSION(2, 4, 83)
 static struct json_object *in_formats_info(int fd, uint32_t blob_id)
 {
 	struct json_object *arr = json_object_new_array();

--- a/json.c
+++ b/json.c
@@ -8,7 +8,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include <json-c/json_object.h>
+#include <json_object.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 

--- a/main.c
+++ b/main.c
@@ -4,7 +4,8 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#include <json-c/json_util.h>
+#include <json_object.h>
+#include <json_util.h>
 
 #include "drm_info.h"
 

--- a/meson.build
+++ b/meson.build
@@ -13,13 +13,10 @@ conf = configuration_data()
 libdrm = dependency('libdrm', version: '>= 2.4.74')
 jsonc = dependency('json-c', version: '>=0.13', fallback: ['json-c', 'json_c'])
 
-# These specific versions added more modifiers, so we check for these instead
-# of using #ifdef on every single one
-foreach version: ['2.4.83', '2.4.91', '2.4.95']
-  conf.set10('HAVE_LIBDRM_' + version.underscorify(),
-    libdrm.version().version_compare('>=' + version)
-  )
-endforeach
+libdrm_ver = libdrm.version().split('.')
+conf.set('LIBDRM_MAJ', libdrm_ver[0])
+conf.set('LIBDRM_MIN', libdrm_ver[1])
+conf.set('LIBDRM_PAT', libdrm_ver[2])
 
 config_h = configure_file(
   configuration: conf,

--- a/meson.build
+++ b/meson.build
@@ -11,7 +11,7 @@ add_project_arguments('-D_POSIX_C_SOURCE=200809L', language: 'c')
 
 conf = configuration_data()
 libdrm = dependency('libdrm', version: '>= 2.4.74')
-jsonc = dependency('json-c', version: '>=0.13')
+jsonc = dependency('json-c', version: '>=0.13', fallback: ['json-c', 'json_c'])
 
 # These specific versions added more modifiers, so we check for these instead
 # of using #ifdef on every single one

--- a/pretty.c
+++ b/pretty.c
@@ -7,46 +7,9 @@
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 
+#include "compat.h"
 #include "config.h"
 #include "drm_info.h"
-
-// Defines for comaptibility with old libdrm
-
-// drm.h
-
-#ifndef DRM_CAP_CRTC_IN_VBLANK_EVENT
-#define DRM_CAP_CRTC_IN_VBLANK_EVENT 0x12
-#endif
-
-#ifndef DRM_CAP_SYNCOBJ
-#define DRM_CAP_SYNCOBJ 0x13
-#endif
-
-#ifndef DRM_CLIENT_CAP_ASPECT_RATIO
-#define DRM_CLIENT_CAP_ASPECT_RATIO 4
-#endif
-
-#ifndef DRM_CLIENT_CAP_WRITEBACK_CONNECTORS
-#define DRM_CLIENT_CAP_WRITEBACK_CONNECTORS 5
-#endif
-
-#ifndef DRM_MODE_CONNECTOR_WRITEBACK
-#define DRM_MODE_CONNECTOR_WRITEBACK 18
-#endif
-
-// drm_fourcc.h
-
-#ifndef DRM_FORMAT_R16
-#define DRM_FORMAT_R16 fourcc_code('R', '1', '6', ' ')
-#endif
-
-#ifndef DRM_FORMAT_RG1616
-#define DRM_FORMAT_RG1616 fourcc_code('R', 'G', '3', '2')
-#endif
-
-#ifndef DRM_FORMAT_GR1616
-#define DRM_FORMAT_GR1616 fourcc_code('G', 'R', '3', '2')
-#endif
 
 #define L_LINE "│   "
 #define L_VAL  "├───"
@@ -377,17 +340,14 @@ static const char *obj_str(uint32_t type)
 	}
 }
 
-#if HAVE_LIBDRM_2_4_83
 static const char *modifier_str(uint64_t modifier)
 {
 	/*
 	 * ARM has a complex format which we can't be bothered to parse.
 	 */
-#if HAVE_LIBDRM_2_4_95
 	if ((modifier >> 56) == DRM_FORMAT_MOD_VENDOR_ARM) {
 		return "DRM_FORMAT_MOD_ARM_AFBC()";
 	}
-#endif
 
 	switch (modifier) {
 	case DRM_FORMAT_MOD_INVALID: return "DRM_FORMAT_MOD_INVALID";
@@ -404,7 +364,6 @@ static const char *modifier_str(uint64_t modifier)
 	case DRM_FORMAT_MOD_VIVANTE_SPLIT_TILED: return "DRM_FORMAT_MOD_VIVANTE_SPLIT_TILED";
 	case DRM_FORMAT_MOD_VIVANTE_SPLIT_SUPER_TILED: return "DRM_FORMAT_MOD_VIVANTE_SPLIT_SUPER_TILED";
 	case DRM_FORMAT_MOD_BROADCOM_VC4_T_TILED: return "DRM_FORMAT_MOD_BROADCOM_VC4_T_TILED";
-#if HAVE_LIBDRM_2_4_91
 	case DRM_FORMAT_MOD_NVIDIA_TEGRA_TILED: return "DRM_FORMAT_MOD_NVIDIA_TEGRA_TILED";
 	case DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_ONE_GOB: return "DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_ONE_GOB";
 	case DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_TWO_GOB: return "DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_TWO_GOB";
@@ -412,14 +371,12 @@ static const char *modifier_str(uint64_t modifier)
 	case DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_EIGHT_GOB: return "DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_EIGHT_GOB";
 	case DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_SIXTEEN_GOB: return "DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_SIXTEEN_GOB";
 	case DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_THIRTYTWO_GOB: return "DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_THIRTYTWO_GOB";
-#endif
-#if HAVE_LIBDRM_2_4_95
 	case DRM_FORMAT_MOD_BROADCOM_SAND32: return "DRM_FORMAT_MOD_BROADCOM_SAND32";
 	case DRM_FORMAT_MOD_BROADCOM_SAND64: return "DRM_FORMAT_MOD_BROADCOM_SAND64";
 	case DRM_FORMAT_MOD_BROADCOM_SAND128: return "DRM_FORMAT_MOD_BROADCOM_SAND128";
 	case DRM_FORMAT_MOD_BROADCOM_SAND256: return "DRM_FORMAT_MOD_BROADCOM_SAND265";
 	case DRM_FORMAT_MOD_BROADCOM_UIF: return "DRM_FORMAT_MOD_BROADCOM_UIF";
-#endif
+	case DRM_FORMAT_MOD_ALLWINNER_TILED: return "DRM_FORMAT_MOD_ALLWINNER_TILED";
 	default: return "unknown";
 	}
 }
@@ -444,13 +401,6 @@ static void print_in_formats(struct json_object *arr, const char *prefix)
 		}
 	}
 }
-#else
-static void print_in_formats(struct json_object *arr, const char *prefix)
-{
-	(void)arr;
-	(void)prefix;
-}
-#endif
 
 static void print_mode_id(struct json_object *obj, const char *prefix)
 {

--- a/pretty.c
+++ b/pretty.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <json-c/json.h>
+#include <json.h>
 #include <drm_fourcc.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>

--- a/subprojects/json-c.wrap
+++ b/subprojects/json-c.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = json-c-0.13.1
+
+source_url = https://s3.amazonaws.com/json-c_releases/releases/json-c-0.13.1.tar.gz
+source_filename = json-c-0.13.1.tar.gz
+source_hash = b87e608d4d3f7bfdd36ef78d56d53c74e66ab278d318b71e6002a369d36f4873
+
+patch_url = https://github.com/ascent12/json-c/releases/download/0.13.1-1/json-c_0.13.1-1_meson.tar.gz
+patch_filename = json-c_0.13.1-1_meson.tar.gz
+patch_hash = 35b3fb0163a8c0359b10f348236a04990d313cb5c56c6fd2e437375f4e9932a6


### PR DESCRIPTION
Adds a meson wrap for building json-c where we don't have 0.13, plus some other cleanup for libdrm defines.

Also, apparently json-c intends people to use <json.h> with -I${prefix}/include/json-c, as that's what their pkg-config and documentation says, so this also swaps over to that. It's also needed for the subproject to work.