### PR TITLE
Remove default case from property "value" marshalling

### DIFF
--- a/json.c
+++ b/json.c
@@ -344,14 +344,21 @@ static struct json_object *properties_info(int fd, uint32_t id, uint32_t type)
 		}
 		json_object_object_add(prop_obj, "spec", spec_obj);
 
-		struct json_object *value_obj;
+		struct json_object *value_obj = NULL;
 		switch (type) {
-		// TODO: DRM_MODE_PROP_BLOB
+		case DRM_MODE_PROP_RANGE:
+		case DRM_MODE_PROP_ENUM:
+		case DRM_MODE_PROP_BITMASK:
+		case DRM_MODE_PROP_OBJECT:
+			value_obj = new_json_object_uint64(value);
+			break;
+		case DRM_MODE_PROP_BLOB:
+			// TODO: base64-encode blob contents
+			value_obj = NULL;
+			break;
 		case DRM_MODE_PROP_SIGNED_RANGE:
 			value_obj = json_object_new_int64((int64_t)value);
 			break;
-		default:
-			value_obj = new_json_object_uint64(value);
 		}
 		json_object_object_add(prop_obj, "value", value_obj);
 


### PR DESCRIPTION
Previously the "value" field of a property object was automatically
filled with the raw uint64_t value by default. In particular, this
happened for blobs.

However I'd like to reserve the "value" field for blobs to contain
the base64-encoded blob contents. If we fill this with a uint64_t
value now, we won't be able to change it to a string later without
breaking consumers.

Additionally, this causes issues for future property types: they
would have their "value" field set to the uint64_t value too, making
it difficult to change it to a more appropriate type later.