### PR TITLE
Update json-c wrap to upstream wrapdb URL

### DIFF
--- a/subprojects/json-c.wrap
+++ b/subprojects/json-c.wrap
@@ -5,6 +5,6 @@ source_url = https://s3.amazonaws.com/json-c_releases/releases/json-c-0.13.1.tar
 source_filename = json-c-0.13.1.tar.gz
 source_hash = b87e608d4d3f7bfdd36ef78d56d53c74e66ab278d318b71e6002a369d36f4873
 
-patch_url = https://github.com/ascent12/json-c/releases/download/0.13.1-1/json-c_0.13.1-1_meson.tar.gz
-patch_filename = json-c_0.13.1-1_meson.tar.gz
-patch_hash = 919cc9ecba2dc95db5aa2cdc9307d2ca92404a88f936d8293fe65d89d3f3d1bb
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/json-c/0.13.1/1/get_zip
+patch_filename = json-c-0.13.1-1-wrap.zip
+patch_hash = 213a735c3c5f7ff4aa38850cd7bf236337c47fd553b9fcded64e709cab66b9fd


### PR DESCRIPTION
I've submitted the json-c wrap upstream and it was just merged.
So we can use that instead of my own repo.