### PR TITLE
Dynamically generate format lookup table from drm_fourcc header

### DIFF
--- a/fourcc.py
+++ b/fourcc.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+import sys
+import re
+
+fourcc_include = sys.argv[1]
+
+fmt_list = []
+mod_list = []
+
+fmt = re.compile(r'^#define (\w+)\s*(?:\\$\s*)?fourcc_code', flags=re.M)
+mod = re.compile(r'^#define (\w+)\s*(?:\\$\s*)?fourcc_mod_code', flags=re.M)
+mod_broadcom = re.compile(r'^#define (DRM_FORMAT_MOD_BROADCOM\w+(?=\s))', flags=re.M)
+
+with open(fourcc_include) as f:
+	for l in f.readlines():
+		ident = fmt.search(l)
+		if ident != None:
+			fmt_list.append(ident.group(1))
+			continue
+		ident = mod.search(l)
+		if ident != None:
+			mod_list.append(ident.group(1))
+			continue
+		ident = mod_broadcom.search(l)
+		if ident != None:
+			mod_list.append(ident.group(1))
+
+f_name = sys.argv[2]
+
+with open(f_name, 'w') as f:
+	f.write('''\
+#include <stdint.h>
+#include <drm_fourcc.h>
+
+static inline const char *format_str(uint32_t format)
+{
+	switch (format) {
+	case DRM_FORMAT_INVALID:
+		return "INVALID";
+''')
+	for ident in fmt_list:
+		f.write('\tcase {}:\n\t\treturn "{}";\n'.format(ident, ident[len('DRM_FORMAT_'):]))
+	f.write('''\
+	default:
+		return "unknown";
+	}
+}
+
+static inline const char *modifier_str(uint64_t modifier)
+{
+	/*
+	 * ARM has a complex format which we can't be bothered to parse.
+	 */
+	if ((modifier >> 56) == DRM_FORMAT_MOD_VENDOR_ARM) {
+		return "DRM_FORMAT_MOD_ARM_AFBC()";
+	}
+
+	switch (modifier) {
+''')
+	for ident in mod_list:
+		f.write('\tcase {}:\n\t\treturn "{}";\n'.format(ident, ident))
+	f.write('''\
+	default:
+		return "unknown";
+	}
+}
+''')

--- a/meson.build
+++ b/meson.build
@@ -23,8 +23,15 @@ config_h = configure_file(
   output: 'config.h',
 )
 
+drm_fourcc_h_path = join_paths(libdrm.get_pkgconfig_variable('includedir'), 'libdrm/drm_fourcc.h')
+fourcc_py = join_paths(meson.source_root(), 'fourcc.py')
+
+tables_h = custom_target('tables_h',
+  output : 'tables.h',
+  command : [fourcc_py, drm_fourcc_h_path, '@OUTPUT@'])
+
 executable('drm_info',
-  files('main.c', 'json.c', 'pretty.c'),
+  [files('main.c', 'json.c', 'pretty.c'), tables_h],
   dependencies: [libdrm, jsonc],
   install: true,
 )

--- a/pretty.c
+++ b/pretty.c
@@ -10,6 +10,7 @@
 #include "compat.h"
 #include "config.h"
 #include "drm_info.h"
+#include "tables.h"
 
 #define L_LINE "│   "
 #define L_VAL  "├───"
@@ -223,80 +224,6 @@ static void print_mode(struct json_object *obj)
 	}
 }
 
-static const char *format_str(uint32_t fmt)
-{
-	switch (fmt) {
-	case DRM_FORMAT_INVALID:     return "invalid";
-	case DRM_FORMAT_C8:          return "C8";
-	case DRM_FORMAT_R8:          return "R8";
-	case DRM_FORMAT_R16:         return "R16";
-	case DRM_FORMAT_RG88:        return "RG88";
-	case DRM_FORMAT_GR88:        return "GR88";
-	case DRM_FORMAT_RG1616:      return "RG1616";
-	case DRM_FORMAT_GR1616:      return "GR1616";
-	case DRM_FORMAT_RGB332:      return "RGB332";
-	case DRM_FORMAT_BGR233:      return "BGR233";
-	case DRM_FORMAT_XRGB4444:    return "XRGB4444";
-	case DRM_FORMAT_XBGR4444:    return "XBGR4444";
-	case DRM_FORMAT_RGBX4444:    return "RGBX4444";
-	case DRM_FORMAT_BGRX4444:    return "BGRX4444";
-	case DRM_FORMAT_ARGB4444:    return "ARGB4444";
-	case DRM_FORMAT_ABGR4444:    return "ABGR4444";
-	case DRM_FORMAT_RGBA4444:    return "RGBA4444";
-	case DRM_FORMAT_BGRA4444:    return "BGRA4444";
-	case DRM_FORMAT_XRGB1555:    return "XRGB1555";
-	case DRM_FORMAT_XBGR1555:    return "XBGR1555";
-	case DRM_FORMAT_RGBX5551:    return "RGBX5551";
-	case DRM_FORMAT_BGRX5551:    return "BGRX5551";
-	case DRM_FORMAT_ARGB1555:    return "ARGB1555";
-	case DRM_FORMAT_ABGR1555:    return "ABGR1555";
-	case DRM_FORMAT_RGBA5551:    return "RGBA5551";
-	case DRM_FORMAT_BGRA5551:    return "BGRA5551";
-	case DRM_FORMAT_RGB565:      return "RGB565";
-	case DRM_FORMAT_BGR565:      return "BGR565";
-	case DRM_FORMAT_RGB888:      return "RGB888";
-	case DRM_FORMAT_BGR888:      return "BGR888";
-	case DRM_FORMAT_XRGB8888:    return "XRGB8888";
-	case DRM_FORMAT_XBGR8888:    return "XBGR8888";
-	case DRM_FORMAT_RGBX8888:    return "RGBX8888";
-	case DRM_FORMAT_BGRX8888:    return "BGRX8888";
-	case DRM_FORMAT_ARGB8888:    return "ARGB8888";
-	case DRM_FORMAT_ABGR8888:    return "ABGR8888";
-	case DRM_FORMAT_RGBA8888:    return "RGBA8888";
-	case DRM_FORMAT_BGRA8888:    return "BGRA8888";
-	case DRM_FORMAT_XRGB2101010: return "XRGB2101010";
-	case DRM_FORMAT_XBGR2101010: return "XBGR2101010";
-	case DRM_FORMAT_RGBX1010102: return "RGBX1010102";
-	case DRM_FORMAT_BGRX1010102: return "BGRX1010102";
-	case DRM_FORMAT_ARGB2101010: return "ARGB2101010";
-	case DRM_FORMAT_ABGR2101010: return "ABGR2101010";
-	case DRM_FORMAT_RGBA1010102: return "RGBA1010102";
-	case DRM_FORMAT_BGRA1010102: return "BGRA1010102";
-	case DRM_FORMAT_YUYV:        return "YUYV";
-	case DRM_FORMAT_YVYU:        return "YVYU";
-	case DRM_FORMAT_UYVY:        return "UYVY";
-	case DRM_FORMAT_VYUY:        return "VYUY";
-	case DRM_FORMAT_AYUV:        return "AYUV";
-	case DRM_FORMAT_NV12:        return "NV12";
-	case DRM_FORMAT_NV21:        return "NV21";
-	case DRM_FORMAT_NV16:        return "NV16";
-	case DRM_FORMAT_NV61:        return "NV61";
-	case DRM_FORMAT_NV24:        return "NV24";
-	case DRM_FORMAT_NV42:        return "NV42";
-	case DRM_FORMAT_YUV410:      return "YUV410";
-	case DRM_FORMAT_YVU410:      return "YVU410";
-	case DRM_FORMAT_YUV411:      return "YUV411";
-	case DRM_FORMAT_YVU411:      return "YVU411";
-	case DRM_FORMAT_YUV420:      return "YUV420";
-	case DRM_FORMAT_YVU420:      return "YVU420";
-	case DRM_FORMAT_YUV422:      return "YUV422";
-	case DRM_FORMAT_YVU422:      return "YVU422";
-	case DRM_FORMAT_YUV444:      return "YUV444";
-	case DRM_FORMAT_YVU444:      return "YVU444";
-	default:                     return "unknown";
-	}
-}
-
 /* Replace well-known constants with strings */
 static const char *u64_str(uint64_t val)
 {
@@ -345,47 +272,6 @@ static const char *obj_str(uint32_t type)
 	case DRM_MODE_OBJECT_PLANE:     return "plane";
 	case DRM_MODE_OBJECT_ANY:       return "any";
 	default:                        return "unknown";
-	}
-}
-
-static const char *modifier_str(uint64_t modifier)
-{
-	/*
-	 * ARM has a complex format which we can't be bothered to parse.
-	 */
-	if ((modifier >> 56) == DRM_FORMAT_MOD_VENDOR_ARM) {
-		return "DRM_FORMAT_MOD_ARM_AFBC()";
-	}
-
-	switch (modifier) {
-	case DRM_FORMAT_MOD_INVALID: return "DRM_FORMAT_MOD_INVALID";
-	case DRM_FORMAT_MOD_LINEAR: return "DRM_FORMAT_MOD_LINEAR";
-	case I915_FORMAT_MOD_X_TILED: return "I915_FORMAT_MOD_X_TILED";
-	case I915_FORMAT_MOD_Y_TILED: return "I915_FORMAT_MOD_Y_TILED";
-	case I915_FORMAT_MOD_Yf_TILED: return "I915_FORMAT_MOD_Yf_TILED";
-	case I915_FORMAT_MOD_Y_TILED_CCS: return "I915_FORMAT_MOD_Y_TILED_CCS";
-	case I915_FORMAT_MOD_Yf_TILED_CCS: return "I915_FORMAT_MOD_Yf_TILED_CSS";
-	case DRM_FORMAT_MOD_SAMSUNG_64_32_TILE: return "DRM_FORMAT_MOD_SAMSUNG_64_32_TILE";
-	// The following formats were added in 2.4.82, but IN_FORMATS wasn't added until 2.4.83
-	case DRM_FORMAT_MOD_VIVANTE_TILED: return "DRM_FORMAT_MOD_VIVANTE_TILED";
-	case DRM_FORMAT_MOD_VIVANTE_SUPER_TILED: return "DRM_FORMAT_MOD_VIVANTE_SUPER_TILED";
-	case DRM_FORMAT_MOD_VIVANTE_SPLIT_TILED: return "DRM_FORMAT_MOD_VIVANTE_SPLIT_TILED";
-	case DRM_FORMAT_MOD_VIVANTE_SPLIT_SUPER_TILED: return "DRM_FORMAT_MOD_VIVANTE_SPLIT_SUPER_TILED";
-	case DRM_FORMAT_MOD_BROADCOM_VC4_T_TILED: return "DRM_FORMAT_MOD_BROADCOM_VC4_T_TILED";
-	case DRM_FORMAT_MOD_NVIDIA_TEGRA_TILED: return "DRM_FORMAT_MOD_NVIDIA_TEGRA_TILED";
-	case DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_ONE_GOB: return "DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_ONE_GOB";
-	case DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_TWO_GOB: return "DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_TWO_GOB";
-	case DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_FOUR_GOB: return "DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_FOUR_GOB";
-	case DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_EIGHT_GOB: return "DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_EIGHT_GOB";
-	case DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_SIXTEEN_GOB: return "DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_SIXTEEN_GOB";
-	case DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_THIRTYTWO_GOB: return "DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_THIRTYTWO_GOB";
-	case DRM_FORMAT_MOD_BROADCOM_SAND32: return "DRM_FORMAT_MOD_BROADCOM_SAND32";
-	case DRM_FORMAT_MOD_BROADCOM_SAND64: return "DRM_FORMAT_MOD_BROADCOM_SAND64";
-	case DRM_FORMAT_MOD_BROADCOM_SAND128: return "DRM_FORMAT_MOD_BROADCOM_SAND128";
-	case DRM_FORMAT_MOD_BROADCOM_SAND256: return "DRM_FORMAT_MOD_BROADCOM_SAND265";
-	case DRM_FORMAT_MOD_BROADCOM_UIF: return "DRM_FORMAT_MOD_BROADCOM_UIF";
-	case DRM_FORMAT_MOD_ALLWINNER_TILED: return "DRM_FORMAT_MOD_ALLWINNER_TILED";
-	default: return "unknown";
 	}
 }
 


### PR DESCRIPTION
This eliminates the need to maintain a list of formats used
for converting from fourcc codes to the prettier version by
parsing drm_fourcc.h directly and building a header for use
in pretty.c