### PR TITLE
Drop dependency on python3 symlink

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -23,12 +23,13 @@ config_h = configure_file(
   output: 'config.h',
 )
 
+python3 = import('python').find_installation()
 drm_fourcc_h_path = join_paths(libdrm.get_pkgconfig_variable('includedir'), 'libdrm/drm_fourcc.h')
 fourcc_py = join_paths(meson.source_root(), 'fourcc.py')
 
 tables_h = custom_target('tables_h',
   output : 'tables.h',
-  command : [fourcc_py, drm_fourcc_h_path, '@OUTPUT@'])
+  command : [python3, fourcc_py, drm_fourcc_h_path, '@OUTPUT@'])
 
 executable('drm_info',
   [files('main.c', 'json.c', 'pretty.c'), tables_h],


### PR DESCRIPTION
See build log [before](https://github.com/ascent12/drm_info/files/3489542/drm_info-2.1.0.7.log) and [after](https://github.com/ascent12/drm_info/files/3489541/drm_info-2.1.0.8.log).


