### PR TITLE
Specify minimum Meson version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 project('drm_info', 'c',
   version: '2.1.0',
   license: 'MIT',
+  meson_version: '>=0.46.0',
   default_options: [
     'c_std=c11',
     'warning_level=2',


### PR DESCRIPTION
Tried to build with 0.45, fails because the python module has been introduced
in 0.46.