### PR TITLE
Fix segfault on drmGetDevices failure

### DIFF
--- a/main.c
+++ b/main.c
@@ -26,6 +26,9 @@ int main(int argc, char *argv[])
 	}
 
 	struct json_object *obj = drm_info(&argv[optind]);
+	if (!obj) {
+		exit(EXIT_FAILURE);
+	}
 	if (json) {
 		json_object_to_fd(STDOUT_FILENO, obj,
 			JSON_C_TO_STRING_PRETTY | JSON_C_TO_STRING_SPACED);


### PR DESCRIPTION
When no DRM devices are detected, drm_info fails with:

    drmGetDevices: No such file or directory

And then segfaults. This happens because the drm_info() function returns
a NULL pointer on failure but main() doesn't handle it.