### PR TITLE
build: download json-c wrap patch from GitHub

### DIFF
--- a/subprojects/json-c.wrap
+++ b/subprojects/json-c.wrap
@@ -5,6 +5,6 @@ source_url = https://s3.amazonaws.com/json-c_releases/releases/json-c-0.13.1.tar
 source_filename = json-c-0.13.1.tar.gz
 source_hash = b87e608d4d3f7bfdd36ef78d56d53c74e66ab278d318b71e6002a369d36f4873
 
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/json-c/0.13.1/1/get_zip
+patch_url = https://github.com/mesonbuild/json-c/releases/download/0.13.1-1/json-c.zip
 patch_filename = json-c-0.13.1-1-wrap.zip
 patch_hash = 213a735c3c5f7ff4aa38850cd7bf236337c47fd553b9fcded64e709cab66b9fd


### PR DESCRIPTION
wrapdb.mesonbuild.com is down. GitHub should be more reliable. The file
is exactly the same.