### PR TITLE
Add support for USB bus types

### DIFF
--- a/json.c
+++ b/json.c
@@ -161,6 +161,14 @@ static struct json_object *device_info(int fd)
 		json_object_object_add(device_data_obj, "subsystem_device",
 			new_json_object_uint64(pci->subdevice_id));
 		break;
+	case DRM_BUS_USB:;
+		drmUsbDeviceInfo *usb = dev->deviceinfo.usb;
+		device_data_obj = json_object_new_object();
+		json_object_object_add(device_data_obj, "vendor",
+			new_json_object_uint64(usb->vendor));
+		json_object_object_add(device_data_obj, "product",
+			new_json_object_uint64(usb->product));
+		break;
 	case DRM_BUS_PLATFORM:;
 		drmPlatformDeviceInfo *platform = dev->deviceinfo.platform;
 		device_data_obj = json_object_new_object();

--- a/pretty.c
+++ b/pretty.c
@@ -100,18 +100,24 @@ static void print_device(struct json_object *obj)
 	printf(L_VAL "Device: %s", bustype_str(bus_type));
 	switch (bus_type) {
 	case DRM_BUS_PCI:;
-		uint16_t vendor = get_object_object_uint64(data_obj, "vendor");
-		uint16_t device = get_object_object_uint64(data_obj, "device");
-		printf(" %04x:%04x", vendor, device);
+		uint16_t pci_vendor = get_object_object_uint64(data_obj, "vendor");
+		uint16_t pci_device = get_object_object_uint64(data_obj, "device");
+		printf(" %04x:%04x", pci_vendor, pci_device);
 #ifdef HAVE_LIBPCI
 		struct pci_access *pci = pci_alloc();
 		char name[512];
 		if (pci_lookup_name(pci, name, sizeof(name),
-				PCI_LOOKUP_VENDOR | PCI_LOOKUP_DEVICE, vendor, device)) {
+				PCI_LOOKUP_VENDOR | PCI_LOOKUP_DEVICE,
+				pci_vendor, pci_device)) {
 			printf(" %s", name);
 		}
 		pci_cleanup(pci);
 #endif
+		break;
+	case DRM_BUS_USB:;
+		uint16_t usb_vendor = get_object_object_uint64(data_obj, "vendor");
+		uint16_t usb_product = get_object_object_uint64(data_obj, "product");
+		printf(" %04x:%04x", usb_vendor, usb_product);
 		break;
 	case DRM_BUS_PLATFORM:;
 		struct json_object *compatible_arr =

--- a/pretty.c
+++ b/pretty.c
@@ -91,6 +91,9 @@ static const char *bustype_str(int type)
 
 static void print_device(struct json_object *obj)
 {
+	if (!obj)
+		return;
+
 	int bus_type = get_object_object_uint64(obj, "bus_type");
 	struct json_object *data_obj = json_object_object_get(obj, "device_data");
 


### PR DESCRIPTION
Currently the USB bus type parsing is broken in libdrm, at least for the devices I have. drmGetDevice fails with -EINVAL.
Already submitted a libdrm MR to fix it: https://gitlab.freedesktop.org/mesa/drm/merge_requests/45