### PR TITLE
Decode HDR_OUTPUT_METADATA

### DIFF
--- a/json.c
+++ b/json.c
@@ -16,6 +16,30 @@
 
 #include "drm_info.h"
 
+// HDR definitions copied from linux/include/uapi/drm/drm_mode.h
+
+struct hdr_metadata_infoframe {
+  uint8_t eotf;
+  uint8_t metadata_type;
+  struct {
+    uint16_t x, y;
+  } display_primaries[3];
+  struct {
+    uint16_t x, y;
+  } white_point;
+  uint16_t max_display_mastering_luminance;
+  uint16_t min_display_mastering_luminance;
+  uint16_t max_cll;
+  uint16_t max_fall;
+};
+
+struct hdr_output_metadata {
+  uint32_t metadata_type;
+  union {
+    struct hdr_metadata_infoframe hdmi_metadata_type1;
+  };
+};
+
 static const struct {
 	const char *name;
 	uint64_t cap;
@@ -271,6 +295,38 @@ static struct json_object *mode_id_info(int fd, uint32_t blob_id)
 	return obj;
 }
 
+static struct json_object *hdr_output_metadata_info(int fd, uint32_t blob_id)
+{
+	drmModePropertyBlobRes *blob = drmModeGetPropertyBlob(fd, blob_id);
+	if (!blob) {
+		perror("drmModeGetPropertyBlob");
+		return NULL;
+	}
+
+	struct hdr_output_metadata *meta = blob->data;
+
+	struct json_object *obj = json_object_new_object();
+	json_object_object_add(obj, "type", new_json_object_uint64(meta->metadata_type));
+	const struct hdr_metadata_infoframe* info = &meta->hdmi_metadata_type1;
+	json_object_object_add(obj, "eotf", new_json_object_uint64(info->eotf));
+	json_object_object_add(obj, "metadata_type", new_json_object_uint64(info->metadata_type));
+	json_object_object_add(obj, "display_primaries_r_x", new_json_object_uint64(info->display_primaries[0].x));
+	json_object_object_add(obj, "display_primaries_r_y", new_json_object_uint64(info->display_primaries[0].y));
+	json_object_object_add(obj, "display_primaries_g_x", new_json_object_uint64(info->display_primaries[1].x));
+	json_object_object_add(obj, "display_primaries_g_y", new_json_object_uint64(info->display_primaries[1].y));
+	json_object_object_add(obj, "display_primaries_b_x", new_json_object_uint64(info->display_primaries[2].x));
+	json_object_object_add(obj, "display_primaries_b_y", new_json_object_uint64(info->display_primaries[2].y));
+	json_object_object_add(obj, "white_point_x", new_json_object_uint64(info->white_point.x));
+	json_object_object_add(obj, "white_point_y", new_json_object_uint64(info->white_point.y));
+	json_object_object_add(obj, "max_display_mastering_luminance", new_json_object_uint64(info->max_display_mastering_luminance));
+	json_object_object_add(obj, "min_display_mastering_luminance", new_json_object_uint64(info->min_display_mastering_luminance));
+	json_object_object_add(obj, "max_cll", new_json_object_uint64(info->max_cll));
+	json_object_object_add(obj, "max_fall", new_json_object_uint64(info->max_fall));
+
+	drmModeFreePropertyBlob(blob);
+	return obj;
+}
+
 static struct json_object *writeback_pixel_formats_info(int fd, uint32_t blob_id)
 {
 	struct json_object *arr = json_object_new_array();
@@ -469,6 +525,8 @@ static struct json_object *properties_info(int fd, uint32_t id, uint32_t type)
 			}
 			if (strcmp(prop->name, "IN_FORMATS") == 0) {
 				data_obj = in_formats_info(fd, value);
+			} else if (strcmp(prop->name, "HDR_OUTPUT_METADATA") == 0) {
+				data_obj = hdr_output_metadata_info(fd, value);
 			} else if (strcmp(prop->name, "MODE_ID") == 0) {
 				data_obj = mode_id_info(fd, value);
 			} else if (strcmp(prop->name, "WRITEBACK_PIXEL_FORMATS") == 0) {

--- a/pretty.c
+++ b/pretty.c
@@ -316,6 +316,20 @@ static void print_in_formats(struct json_object *arr, const char *prefix)
 	}
 }
 
+static void print_hdr_output_metadata(struct json_object *arr, const char *prefix)
+{
+	struct json_object_iter iter;
+	json_object_object_foreachC(arr, iter) {
+		if (iter.val) {
+			printf("%s%s\"%s\" = %"PRIu64"\n",
+				prefix,
+				!iter.entry->next ? L_LINE L_LAST : L_LINE L_VAL,
+				iter.key,
+				get_object_uint64(iter.val));
+		}
+	}
+}
+
 static void print_mode_id(struct json_object *obj, const char *prefix)
 {
 	printf("%s" L_LAST, prefix);
@@ -467,6 +481,8 @@ static void print_properties(struct json_object *obj, const char *prefix)
 				break;
 			if (strcmp(prop_name, "IN_FORMATS") == 0)
 				print_in_formats(data_obj, sub_prefix);
+			else if (strcmp(prop_name, "HDR_OUTPUT_METADATA") == 0)
+				print_hdr_output_metadata(data_obj, sub_prefix);
 			else if (strcmp(prop_name, "MODE_ID") == 0)
 				print_mode_id(data_obj, sub_prefix);
 			else if (strcmp(prop_name, "WRITEBACK_PIXEL_FORMATS") == 0)


### PR DESCRIPTION
This was essential in debugging some HDR enablement code I'm working on.

In the pretty-print output, all fields are decoded to integers.
If someone deems it useful, I could put in the extra work to show enum
names and convert the fixed-point values to floats in the 0.0-1.0 range.

In the JSON output, I deliberately flattened the primaries to separate
fields for the B, G and B components because I felt that the array
notation is less readable.