### PR TITLE
WIP: Add a manpage

### DIFF
--- a/drm_info.1
+++ b/drm_info.1
@@ -1,0 +1,15 @@
+.TH DRM_INFO: "1" "June 2020" "drm_info" "User Commands"
+.SH NAME
+drm_info \- Dump information about DRM devices
+.SH SYNOPSIS
+\fBdrm_info\fR
+[\fB-j\fR] [\fB--\fR] [\fBpath\fR]
+.SH DESCRIPTION
+drm_info is used to dump information about DRM
+devices, planes, encoders, crtcs, planes and their DRM properties
+.SH OPTIONS
+.TP
+\fB\-\j\fR
+Output in json format
+.SH AUTHOR
+Scott Anderson <scott@anderso.nz>


### PR DESCRIPTION
Hi,

as part of debian packaging [1] I wrote a manpage for `drm_info`
and I was wondering whether you would be interested in having it upstream.
I still have to figure out how to install the manpage within meson/ninja, but I wanted to
open this pull request so I can gauge interest.

[1] https://salsa.debian.org/swaywm-team/drm-info

Cheers

fortysixandtwo