### PR TITLE
Add support for AMD modifiers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -42,7 +42,7 @@ inc = []
 #
 # We need to make sure we don't use any new libdrm functions, but those
 # are added very infrequently, so this is unlikely to be an issue.
-if libdrm.version().version_compare('<2.4.99')
+if libdrm.version().version_compare('<2.4.104')
   if libdrm.type_name() == 'internal'
     error('libdrm subproject out of date. Run `meson subprojects update`.')
   endif

--- a/modifiers.c
+++ b/modifiers.c
@@ -22,6 +22,115 @@ static void print_nvidia_modifier(uint64_t mod) {
 		"s=%"PRIu64", c=%"PRIu64")", h, k, g, s, c);
 }
 
+static const char *amd_tile_version_str(uint64_t tile_version) {
+	switch (tile_version) {
+	case AMD_FMT_MOD_TILE_VER_GFX9:
+		return "GFX9";
+	case AMD_FMT_MOD_TILE_VER_GFX10:
+		return "GFX10";
+	case AMD_FMT_MOD_TILE_VER_GFX10_RBPLUS:
+		return "GFX10_RBPLUS";
+	}
+	return "Unknown";
+}
+
+static const char *amd_tile_str(uint64_t tile, uint64_t tile_version) {
+	switch (tile_version) {
+	case AMD_FMT_MOD_TILE_VER_GFX10_RBPLUS:
+		/* fallthrough */
+	case AMD_FMT_MOD_TILE_VER_GFX10:
+		/* fallthrough */
+	case AMD_FMT_MOD_TILE_VER_GFX9:
+		switch (tile) {
+		case AMD_FMT_MOD_TILE_GFX9_64K_S:
+			return "GFX9_64K_S";
+		case AMD_FMT_MOD_TILE_GFX9_64K_D:
+			return "GFX9_64K_D";
+		case AMD_FMT_MOD_TILE_GFX9_64K_S_X:
+			return "GFX9_64K_S_X";
+		case AMD_FMT_MOD_TILE_GFX9_64K_D_X:
+			return "GFX9_64K_D_X";
+		case AMD_FMT_MOD_TILE_GFX9_64K_R_X:
+			return "GFX9_64K_R_X";
+		}
+	}
+	return "Unknown";
+}
+
+static const char *amd_dcc_block_size_str(uint64_t size) {
+	switch (size) {
+	case AMD_FMT_MOD_DCC_BLOCK_64B:
+		return "64B";
+	case AMD_FMT_MOD_DCC_BLOCK_128B:
+		return "128B";
+	case AMD_FMT_MOD_DCC_BLOCK_256B:
+		return "256B";
+	}
+	return "Unknown";
+}
+
+static bool amd_gfx9_tile_is_x_t(uint64_t tile) {
+	switch (tile) {
+	case AMD_FMT_MOD_TILE_GFX9_64K_S_X:
+	case AMD_FMT_MOD_TILE_GFX9_64K_D_X:
+	case AMD_FMT_MOD_TILE_GFX9_64K_R_X:
+		return true;
+	}
+	return false;
+}
+
+static void print_amd_modifier(uint64_t mod) {
+	uint64_t tile_version = AMD_FMT_MOD_GET(TILE_VERSION, mod);
+	uint64_t tile = AMD_FMT_MOD_GET(TILE, mod);
+	uint64_t dcc = AMD_FMT_MOD_GET(DCC, mod);
+	uint64_t dcc_retile = AMD_FMT_MOD_GET(DCC_RETILE, mod);
+
+	printf("AMD(TILE_VERSION = %s, TILE = %s",
+		amd_tile_version_str(tile_version), amd_tile_str(tile, tile_version));
+
+	if (dcc) {
+		printf(", DCC");
+		if (dcc_retile) {
+			printf(", DCC_RETILE");
+		}
+		if (!dcc_retile && AMD_FMT_MOD_GET(DCC_PIPE_ALIGN, mod)) {
+			printf(", DCC_PIPE_ALIGN");
+		}
+		if (AMD_FMT_MOD_GET(DCC_INDEPENDENT_64B, mod)) {
+			printf(", DCC_INDEPENDENT_64B");
+		}
+		if (AMD_FMT_MOD_GET(DCC_INDEPENDENT_128B, mod)) {
+			printf(", DCC_INDEPENDENT_128B");
+		}
+		uint64_t dcc_max_compressed_block =
+			AMD_FMT_MOD_GET(DCC_MAX_COMPRESSED_BLOCK, mod);
+		printf(", DCC_MAX_COMPRESSED_BLOCK = %s",
+			amd_dcc_block_size_str(dcc_max_compressed_block));
+		if (AMD_FMT_MOD_GET(DCC_CONSTANT_ENCODE, mod)) {
+			printf(", DCC_CONSTANT_ENCODE");
+		}
+	}
+
+	if (tile_version >= AMD_FMT_MOD_TILE_VER_GFX9 && amd_gfx9_tile_is_x_t(tile)) {
+		printf(", PIPE_XOR_BITS = %"PRIu64, AMD_FMT_MOD_GET(PIPE_XOR_BITS, mod));
+		if (tile_version == AMD_FMT_MOD_TILE_VER_GFX9) {
+			printf(", BANK_XOR_BITS = %"PRIu64, AMD_FMT_MOD_GET(BANK_XOR_BITS, mod));
+		}
+		if (tile_version == AMD_FMT_MOD_TILE_VER_GFX10_RBPLUS) {
+			printf(", PACKERS = %"PRIu64, AMD_FMT_MOD_GET(PACKERS, mod));
+		}
+		if (tile_version == AMD_FMT_MOD_TILE_VER_GFX9 && dcc) {
+			printf(", RB = %"PRIu64, AMD_FMT_MOD_GET(RB, mod));
+		}
+		if (tile_version == AMD_FMT_MOD_TILE_VER_GFX9 && dcc &&
+				(dcc_retile || AMD_FMT_MOD_GET(DCC_PIPE_ALIGN, mod))) {
+			printf(", PIPE = %"PRIu64, AMD_FMT_MOD_GET(PIPE, mod));
+		}
+	}
+
+	printf(")");
+}
+
 static uint8_t mod_vendor(uint64_t mod) {
 	return (uint8_t)(mod >> 56);
 }
@@ -30,6 +139,9 @@ void print_modifier(uint64_t mod) {
 	switch (mod_vendor(mod)) {
 	case DRM_FORMAT_MOD_VENDOR_NVIDIA:
 		print_nvidia_modifier(mod);
+		break;
+	case DRM_FORMAT_MOD_VENDOR_AMD:
+		print_amd_modifier(mod);
 		break;
 	default:
 		printf("%s", basic_modifier_str(mod));

--- a/subprojects/libdrm.wrap
+++ b/subprojects/libdrm.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/mesa/drm.git
-revision = libdrm-2.4.99
+revision = libdrm-2.4.104
 depth = 1


### PR DESCRIPTION
~~Depends on https://github.com/ascent12/drm_info/pull/60~~

It's not possible in practice to explicitly enumerate all modifiers, because they are very complicated. Instead, rely on drm_fourcc.h macros and manually format a string.

Closes: #62

cc @bnieuwenhuizen