### PR TITLE
Fix bitmask pretty-printing

### DIFF
--- a/pretty.c
+++ b/pretty.c
@@ -512,7 +512,8 @@ static void print_properties(struct json_object *obj, const char *prefix)
 					get_object_object_string(item_obj, "name");
 				uint64_t item_value =
 					get_object_object_uint64(item_obj, "value");
-				if ((item_value & raw_val) != item_value) {
+				uint64_t item_bit = 1 << item_value;
+				if ((item_bit & raw_val) != item_bit) {
 					continue;
 				}
 


### PR DESCRIPTION
The kernel sets the enum values to the number of left shifts, the enum
values aren't bits we can use directly.

See for instance drm_plane_create_rotation_property [1].

[1]: https://cgit.freedesktop.org/drm-tip/tree/drivers/gpu/drm/drm_blend.c#n282