### PR TITLE
Manually parse ARM AFBC modifiers

### DIFF
--- a/fourcc.py
+++ b/fourcc.py
@@ -2,30 +2,15 @@
 
 import sys
 import re
-from itertools import chain, combinations
-
-def powerset(s):
-	return chain.from_iterable(combinations(s, r) for r in range(len(s) + 1))
 
 def case_print(f, c, s):
 	f.write('\tcase {}:\n'.format(c))
 	f.write('\t\treturn "{}";\n'.format(s))
 
-def afbc_print(f, l):
-	fmt = 'DRM_FORMAT_MOD_ARM_AFBC({})'
-	if l:
-		# Strip prefix to stop string being stupidly long
-		short = [s[len('AFBC_FORMAT_MOD_'):] for s in l]
-		case_print(f, fmt.format('|'.join(l)), fmt.format('|'.join(short)))
-	else:
-		case_print(f, fmt.format(0), fmt.format(0))
-
 info = {
 	'fmt': r'^#define (\w+)\s*(?:\\$\s*)?fourcc_code',
 	'basic_pre': r'^#define (I915_FORMAT_MOD_\w+)\b',
 	'basic_post': r'^#define (DRM_FORMAT_MOD_(?:INVALID|LINEAR|SAMSUNG|QCOM|VIVANTE|NVIDIA|BROADCOM|ALLWINNER)\w*)\s',
-	'afbc_block': r'\bAFBC_FORMAT_MOD_BLOCK_SIZE(?:_\d+x\d+)+\b',
-	'afbc_bitmask': r'\bAFBC_FORMAT_MOD_[A-Z]+\b',
 }
 
 with open(sys.argv[1], 'r') as f:
@@ -63,17 +48,6 @@ const char *basic_modifier_str(uint64_t modifier)
 
 	for ident in info['basic_pre'] + info['basic_post']:
 		case_print(f, ident, ident)
-
-	# ARM framebuffer compression
-	# Not all of the combintations we generate will be valid modifers exposed
-	# by the driver
-
-	for bits in powerset(info['afbc_bitmask']):
-		bits = list(bits)
-		bits.sort()
-		afbc_print(f, bits)
-		for block in info['afbc_block']:
-			afbc_print(f, bits + [block])
 
 	f.write('''\
 	default:

--- a/modifiers.c
+++ b/modifiers.c
@@ -131,6 +131,71 @@ static void print_amd_modifier(uint64_t mod) {
 	printf(")");
 }
 
+static const char *arm_afbc_block_size_str(uint64_t block_size) {
+	switch (block_size) {
+	case AFBC_FORMAT_MOD_BLOCK_SIZE_16x16:
+		return "16x16";
+	case AFBC_FORMAT_MOD_BLOCK_SIZE_32x8:
+		return "32x8";
+	case AFBC_FORMAT_MOD_BLOCK_SIZE_64x4:
+		return "64x4";
+	case AFBC_FORMAT_MOD_BLOCK_SIZE_32x8_64x4:
+		return "32x8_64x4";
+	}
+	return "Unknown";
+}
+
+static void print_arm_modifier(uint64_t mod) {
+	uint64_t type = (mod >> 52) & 0xF;
+	uint64_t value = mod & 0x000FFFFFFFFFFFFFULL;
+
+	switch (type) {
+	case DRM_FORMAT_MOD_ARM_TYPE_AFBC:;
+		uint64_t block_size = value & AFBC_FORMAT_MOD_BLOCK_SIZE_MASK;
+		printf("ARM_AFBC(BLOCK_SIZE = %s", arm_afbc_block_size_str(block_size));
+		if (value & AFBC_FORMAT_MOD_YTR) {
+			printf(", YTR");
+		}
+		if (value & AFBC_FORMAT_MOD_SPLIT) {
+			printf(", SPLIT");
+		}
+		if (value & AFBC_FORMAT_MOD_SPARSE) {
+			printf(", SPARSE");
+		}
+		if (value & AFBC_FORMAT_MOD_CBR) {
+			printf(", CBR");
+		}
+		if (value & AFBC_FORMAT_MOD_TILED) {
+			printf(", TILED");
+		}
+		if (value & AFBC_FORMAT_MOD_SC) {
+			printf(", SC");
+		}
+		if (value & AFBC_FORMAT_MOD_DB) {
+			printf(", DB");
+		}
+		if (value & AFBC_FORMAT_MOD_BCH) {
+			printf(", BCH");
+		}
+		if (value & AFBC_FORMAT_MOD_USM) {
+			printf(", USM");
+		}
+		printf(")");
+		break;
+	case DRM_FORMAT_MOD_ARM_TYPE_MISC:
+		switch (mod) {
+		case DRM_FORMAT_MOD_ARM_16X16_BLOCK_U_INTERLEAVED:
+			printf("ARM_16X16_BLOCK_U_INTERLEAVED");
+			break;
+		default:
+			printf("ARM_MISC(unknown)");
+		}
+		break;
+	default:
+		printf("ARM(unknown)");
+	}
+}
+
 static uint8_t mod_vendor(uint64_t mod) {
 	return (uint8_t)(mod >> 56);
 }
@@ -142,6 +207,9 @@ void print_modifier(uint64_t mod) {
 		break;
 	case DRM_FORMAT_MOD_VENDOR_AMD:
 		print_amd_modifier(mod);
+		break;
+	case DRM_FORMAT_MOD_VENDOR_ARM:
+		print_arm_modifier(mod);
 		break;
 	default:
 		printf("%s", basic_modifier_str(mod));


### PR DESCRIPTION
Instead of enumerating all cases with a powerset via code generation,
parse the ARM modifiers manually just like the other modifiers.