### PR TITLE
Print plane legacy FB

### DIFF
--- a/json.c
+++ b/json.c
@@ -672,6 +672,9 @@ static struct json_object *planes_info(int fd)
 		json_object_object_add(plane_obj, "gamma_size",
 			new_json_object_uint64(plane->gamma_size));
 
+		json_object_object_add(plane_obj, "fb",
+			plane->fb_id ? fb_info(fd, plane->fb_id) : NULL);
+
 		struct json_object *formats_arr = json_object_new_array();
 		for (uint32_t j = 0; j < plane->count_formats; ++j) {
 			json_object_array_add(formats_arr,

--- a/pretty.c
+++ b/pretty.c
@@ -818,6 +818,8 @@ static void print_planes(struct json_object *arr)
 
 		uint32_t id = get_object_object_uint64(obj, "id");
 		uint32_t crtcs = get_object_object_uint64(obj, "possible_crtcs");
+		uint32_t fb_id = get_object_object_uint64(obj, "fb_id");
+		struct json_object *fb_obj = json_object_object_get(obj, "fb");
 		struct json_object *formats_arr = json_object_object_get(obj, "formats");
 		struct json_object *props_obj = json_object_object_get(obj, "properties");
 
@@ -828,6 +830,12 @@ static void print_planes(struct json_object *arr)
 		printf(L_GAP "%s" L_VAL "CRTCs: ", last ? L_GAP : L_LINE);
 		print_bitmask(crtcs);
 		printf("\n");
+
+		printf(L_GAP "%s" L_VAL "FB ID: %"PRIu32"\n",
+			last ? L_GAP : L_LINE, fb_id);
+		if (fb_obj) {
+			print_fb(fb_obj, last ? L_GAP L_GAP L_LINE : L_GAP L_LINE L_LINE);
+		}
 
 		printf(L_GAP "%s" L_VAL "Formats:\n", last ? L_GAP : L_LINE);
 		for (size_t j = 0; j < json_object_array_length(formats_arr); ++j) {


### PR DESCRIPTION
Some drivers (nouveau, radeon) don't have the FB_ID property, because
they aren't atomic. We can still display the legacy FB information in
this case.