### PR TITLE
Use drmModeGetConnectorCurrent

### DIFF
--- a/json.c
+++ b/json.c
@@ -512,9 +512,9 @@ static struct json_object *connectors_info(int fd, drmModeRes *res)
 	struct json_object *arr = json_object_new_array();
 
 	for (int i = 0; i < res->count_connectors; ++i) {
-		drmModeConnector *conn = drmModeGetConnector(fd, res->connectors[i]);
+		drmModeConnector *conn = drmModeGetConnectorCurrent(fd, res->connectors[i]);
 		if (!conn) {
-			perror("drmModeGetConnector");
+			perror("drmModeGetConnectorCurrent");
 			continue;
 		}
 


### PR DESCRIPTION
drmModeGetConnector performs an active probe on older kernels.
The drmModeGetConnectorCurrent variant doesn't mutate the kernel
state. Since [1], drmModeGetConnector will be demoted to
drmModeGetConnectorCurrent if the client isn't DRM master.

Since we should never be DRM master, align our expectations with
the latest kernel.

[1]: https://cgit.freedesktop.org/drm/drm-misc/commit/?id=8f86c82aba8b13e732cfdd6d0e19a7dd48197e43