### PR TITLE
Show devices where `drmModeGetResources` raises `EOPNOTSUPP`

### DIFF
--- a/json.c
+++ b/json.c
@@ -713,7 +713,15 @@ static struct json_object *node_info(const char *path)
 	json_object_object_add(obj, "device", device_info(fd));
 
 	drmModeRes *res = drmModeGetResources(fd);
-	if (!res) {
+	if (!res && errno == EOPNOTSUPP) {
+		// Some DRM devices don't have resources
+		json_object_object_add(obj, "connectors", json_object_new_array());
+		json_object_object_add(obj, "encoders", json_object_new_array());
+		json_object_object_add(obj, "crtcs", json_object_new_array());
+		json_object_object_add(obj, "planes", json_object_new_array());
+		close(fd);
+		return obj;
+	} else if (!res) {
 		perror("drmModeGetResources");
 		close(fd);
 		json_object_put(obj);


### PR DESCRIPTION
It seems DRM devices like the Panfrost driver on the RK3399 in the Pinebook Pro raise this error here. (Connectors, etc. are a separate device provided by the `rockchip` driver). This allows `drm_info` to provide some useful output instead of skipping the device.

Example:
```
Node: /dev/dri/card0
├───Driver: panfrost (panfrost DRM) version 1.2.0 (20180908)
│   ├───DRM_CLIENT_CAP_STEREO_3D not supported
│   ├───DRM_CLIENT_CAP_UNIVERSAL_PLANES not supported
│   ├───DRM_CLIENT_CAP_ATOMIC not supported
│   ├───DRM_CLIENT_CAP_ASPECT_RATIO not supported
│   ├───DRM_CLIENT_CAP_WRITEBACK_CONNECTORS not supported
│   ├───DRM_CAP_DUMB_BUFFER not supported
│   ├───DRM_CAP_VBLANK_HIGH_CRTC not supported
│   ├───DRM_CAP_DUMB_PREFERRED_DEPTH not supported
│   ├───DRM_CAP_DUMB_PREFER_SHADOW not supported
│   ├───DRM_CAP_PRIME = 3
│   ├───DRM_CAP_TIMESTAMP_MONOTONIC = 1
│   ├───DRM_CAP_ASYNC_PAGE_FLIP not supported
│   ├───DRM_CAP_CURSOR_WIDTH not supported
│   ├───DRM_CAP_CURSOR_HEIGHT not supported
│   ├───DRM_CAP_ADDFB2_MODIFIERS not supported
│   ├───DRM_CAP_PAGE_FLIP_TARGET not supported
│   ├───DRM_CAP_CRTC_IN_VBLANK_EVENT not supported
│   ├───DRM_CAP_SYNCOBJ = 1
│   └───DRM_CAP_SYNCOBJ_TIMELINE = 0
├───Device: platform rockchip,rk3399-mali arm,mali-t860
│   └───Available nodes: primary, render
├───Framebuffer size
│   ├───Width: [0, 0]
│   └───Height: [0, 0]
├───Connectors
├───Encoders
├───CRTCs
└───Planes
```